### PR TITLE
Add currency accessor to Transaction

### DIFF
--- a/lib/paymill/transaction.rb
+++ b/lib/paymill/transaction.rb
@@ -5,7 +5,7 @@ module Paymill
     include Paymill::Operations::Find
 
     attr_accessor :id, :amount, :status, :description, :livemode,
-                  :payment, :client, :created_at, :updated_at
+                  :payment, :currency, :client, :created_at, :updated_at
 
     def initialize(attributes = {})
       attributes.each_pair do |key, value|

--- a/spec/paymill/transaction_spec.rb
+++ b/spec/paymill/transaction_spec.rb
@@ -4,6 +4,7 @@ describe Paymill::Transaction do
   let(:valid_attributes) do
     {
       amount: 4200,
+      currency: "EUR",
       status: "pending",
       description: "Test transaction.",
       livemode: false,
@@ -28,6 +29,7 @@ describe Paymill::Transaction do
       transaction.payment[:card_type].should eql("visa")
       transaction.payment[:country].should eql("germany")
       transaction.client.should eql("client_a013c")
+      transaction.currency.should eql("EUR")
     end
   end
 


### PR DESCRIPTION
Noticed that the Transaction object has currency in it, however it is not directly accessible.
