### PR TITLE
Adding update to instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,22 @@ Or find an existing client:
 
     Paymill::Client.find("client_88a388d9dd48f86c3136")
 
+Updating an existing client only works on an instance:
+
+    client = Paymill::Client.find("client_88a388d9dd48f86c3136")
+    client.update(:email => "carl.client@example.com")
+
+Deleting a client:
+
+  Paymill::Client.delete("client_88a388d9dd48f86c3136")
+
+
 For retrieving a collection of all clients you might use the `all`
 operation:
 
     Paymill::Client.all
 
-We currently only support the operations `create`, `find` and `all`.
+Please note that Transactions and Payments may not be able to be updated at all.
 
 Requirements
 =====

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Updating an existing client only works on an instance:
 
 Deleting a client:
 
-  Paymill::Client.delete("client_88a388d9dd48f86c3136")
+    Paymill::Client.delete("client_88a388d9dd48f86c3136")
 
 
 For retrieving a collection of all clients you might use the `all`

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -19,8 +19,9 @@ module Paymill
   module Operations
     autoload :All,    "paymill/operations/all"
     autoload :Create, "paymill/operations/create"
-    autoload :Delete, "paymill/operations/delete"
     autoload :Find,   "paymill/operations/find"
+    autoload :Update, "paymill/operations/update"
+    autoload :Delete, "paymill/operations/delete"
   end
 
   class PaymillError < StandardError

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -51,13 +51,15 @@ module Paymill
         https_request = case http_method
               when :post
                 Net::HTTP::Post.new(url)
+              when :put
+                Net::HTTP::Put.new(url)
               when :delete
                 Net::HTTP::Delete.new(url)
               else
                 Net::HTTP::Get.new(url)
               end
         https_request.basic_auth(api_key, "")
-        https_request.set_form_data(data) if http_method == :post
+        https_request.set_form_data(data) if [:post, :put].include? http_method
         @response = https.request(https_request)
       end
       raise AuthenticationError if @response.code.to_i == 401

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -9,6 +9,7 @@ module Paymill
 
   @@api_key = nil
 
+  autoload :Base,         "paymill/base"
   autoload :Client,       "paymill/client"
   autoload :Offer,        "paymill/offer"
   autoload :Payment,      "paymill/payment"

--- a/lib/paymill/base.rb
+++ b/lib/paymill/base.rb
@@ -1,0 +1,15 @@
+module Paymill
+  class Base
+
+    def initialize(attributes = {})
+      set_attributes(attributes)
+    end
+
+    def set_attributes(attributes)
+      attributes.each_pair do |key, value|
+        instance_variable_set("@#{key}", value)
+      end
+    end
+
+  end
+end

--- a/lib/paymill/client.rb
+++ b/lib/paymill/client.rb
@@ -2,8 +2,9 @@ module Paymill
   class Client < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
-    include Paymill::Operations::Delete
     include Paymill::Operations::Find
+    include Paymill::Operations::Update
+    include Paymill::Operations::Delete
 
     attr_accessor :id, :email, :description, :attributes, :created_at,
                   :updated_at, :payment, :subscription

--- a/lib/paymill/client.rb
+++ b/lib/paymill/client.rb
@@ -1,5 +1,5 @@
 module Paymill
-  class Client
+  class Client < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
     include Paymill::Operations::Delete
@@ -8,10 +8,5 @@ module Paymill
     attr_accessor :id, :email, :description, :attributes, :created_at,
                   :updated_at, :payment, :subscription
 
-    def initialize(attributes = {})
-      attributes.each_pair do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
   end
 end

--- a/lib/paymill/offer.rb
+++ b/lib/paymill/offer.rb
@@ -2,8 +2,9 @@ module Paymill
   class Offer < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
-    include Paymill::Operations::Delete
     include Paymill::Operations::Find
+    include Paymill::Operations::Update
+    include Paymill::Operations::Delete
 
     attr_accessor :id, :name, :amount, :interval, :trial_period_days, :currency
 

--- a/lib/paymill/offer.rb
+++ b/lib/paymill/offer.rb
@@ -1,5 +1,5 @@
 module Paymill
-  class Offer
+  class Offer < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
     include Paymill::Operations::Delete
@@ -7,10 +7,6 @@ module Paymill
 
     attr_accessor :id, :name, :amount, :interval, :trial_period_days, :currency
 
-    def initialize(attributes = {})
-      attributes.each_pair do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
+
   end
 end

--- a/lib/paymill/operations/update.rb
+++ b/lib/paymill/operations/update.rb
@@ -1,0 +1,12 @@
+module Paymill
+  module Operations
+    module Update
+
+      def update(attributes)
+        response = Paymill.request(:put, "#{self.class.name.split("::").last.downcase}s/#{id}", attributes)
+        set_attributes(response["data"])
+      end
+
+    end
+  end
+end

--- a/lib/paymill/payment.rb
+++ b/lib/paymill/payment.rb
@@ -1,5 +1,5 @@
 module Paymill
-  class Payment
+  class Payment < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
     include Paymill::Operations::Find
@@ -7,10 +7,5 @@ module Paymill
     attr_accessor :id, :card_type, :country, :expire_month, :expire_year,
                   :card_holder, :last4, :created_at, :updated_at
 
-    def initialize(attributes = {})
-      attributes.each_pair do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
   end
 end

--- a/lib/paymill/subscription.rb
+++ b/lib/paymill/subscription.rb
@@ -1,5 +1,5 @@
 module Paymill
-  class Subscription
+  class Subscription < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
     include Paymill::Operations::Delete
@@ -8,10 +8,6 @@ module Paymill
     attr_accessor :id, :plan, :livemode, :cancel_at_period_end, :created_at, :updated_at,
                   :canceled_at, :client
 
-    def initialize(attributes = {})
-      attributes.each_pair do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
+
   end
 end

--- a/lib/paymill/subscription.rb
+++ b/lib/paymill/subscription.rb
@@ -2,8 +2,9 @@ module Paymill
   class Subscription < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
-    include Paymill::Operations::Delete
     include Paymill::Operations::Find
+    include Paymill::Operations::Update
+    include Paymill::Operations::Delete
 
     attr_accessor :id, :plan, :livemode, :cancel_at_period_end, :created_at, :updated_at,
                   :canceled_at, :client

--- a/lib/paymill/transaction.rb
+++ b/lib/paymill/transaction.rb
@@ -1,5 +1,5 @@
 module Paymill
-  class Transaction
+  class Transaction < Base
     include Paymill::Operations::All
     include Paymill::Operations::Create
     include Paymill::Operations::Find
@@ -7,10 +7,5 @@ module Paymill
     attr_accessor :id, :amount, :status, :description, :livemode,
                   :payment, :currency, :client, :created_at, :updated_at
 
-    def initialize(attributes = {})
-      attributes.each_pair do |key, value|
-        instance_variable_set("@#{key}", value)
-      end
-    end
   end
 end

--- a/spec/paymill/client_spec.rb
+++ b/spec/paymill/client_spec.rb
@@ -45,20 +45,20 @@ describe Paymill::Client do
   end
 
   describe "#update" do
-      it "makes a new PUT request using the correct API endpoint" do
-        client.id    = "client_123"
-        Paymill.should_receive(:request).with(:put, "clients/client_123", {:email => "tim.test@exmaple.com"}).and_return("data" => {})
+    it "makes a new PUT request using the correct API endpoint" do
+      client.id = "client_123"
+      Paymill.should_receive(:request).with(:put, "clients/client_123", {:email => "tim.test@exmaple.com"}).and_return("data" => {})
 
-        client.update({:email => "tim.test@exmaple.com"})
-      end
-
-      it "updates the instance with the returned attributes" do
-        changed_attributes = {:email => "tim.test@example.com"}
-        Paymill.should_receive(:request).and_return("data" => changed_attributes)
-        client.update(changed_attributes)
-
-        client.email.should eql("tim.test@example.com")
-      end
-
+      client.update({:email => "tim.test@exmaple.com"})
     end
+
+    it "updates the instance with the returned attributes" do
+      changed_attributes = {:email => "tim.test@example.com"}
+      Paymill.should_receive(:request).and_return("data" => changed_attributes)
+      client.update(changed_attributes)
+
+      client.email.should eql("tim.test@example.com")
+    end
+
+  end
 end

--- a/spec/paymill/client_spec.rb
+++ b/spec/paymill/client_spec.rb
@@ -43,4 +43,22 @@ describe Paymill::Client do
       Paymill::Client.create(valid_attributes)
     end
   end
+
+  describe "#update" do
+      it "makes a new PUT request using the correct API endpoint" do
+        client.id    = "client_123"
+        Paymill.should_receive(:request).with(:put, "clients/client_123", {:email => "tim.test@exmaple.com"}).and_return("data" => {})
+
+        client.update({:email => "tim.test@exmaple.com"})
+      end
+
+      it "updates the instance with the returned attributes" do
+        changed_attributes = {:email => "tim.test@example.com"}
+        Paymill.should_receive(:request).and_return("data" => changed_attributes)
+        client.update(changed_attributes)
+
+        client.email.should eql("tim.test@example.com")
+      end
+
+    end
 end

--- a/spec/paymill/offer_spec.rb
+++ b/spec/paymill/offer_spec.rb
@@ -3,10 +3,10 @@ require "spec_helper"
 describe Paymill::Offer do
   let(:valid_attributes) do
     {
-      amount: 4200,
+      amount:   4200,
       currency: "eur",
       interval: "month",
-      name: "Medium Plan"
+      name:     "Medium Plan"
     }
   end
 
@@ -49,5 +49,23 @@ describe Paymill::Offer do
       Paymill.should_receive(:request).with(:post, "offers", valid_attributes).and_return("data" => {})
       Paymill::Offer.create(valid_attributes)
     end
+  end
+
+  describe "#update" do
+    it "makes a new PUT request using the correct API endpoint" do
+      offer.id = "offer_123"
+      Paymill.should_receive(:request).with(:put, "offers/offer_123", {:name => "Large Plan"}).and_return("data" => {})
+
+      offer.update({:name => "Large Plan"})
+    end
+
+    it "updates the instance with the returned attributes" do
+      changed_attributes = {:name => "Large Plan"}
+      Paymill.should_receive(:request).and_return("data" => changed_attributes)
+      offer.update(changed_attributes)
+
+      offer.name.should eql("Large Plan")
+    end
+
   end
 end

--- a/spec/paymill/subscription_spec.rb
+++ b/spec/paymill/subscription_spec.rb
@@ -58,4 +58,17 @@ describe Paymill::Subscription do
       Paymill::Subscription.create(valid_attributes)
     end
   end
+
+  describe "#update" do
+    it "makes a new PUT request using the correct API endpoint" do
+      changed_attributes = { :cancel_at_period_end => true }
+      subscription.id = 'sub_123'
+
+      Paymill.should_receive(:request).with(:put, "subscriptions/sub_123", changed_attributes).and_return("data" => {})
+
+      subscription.update(changed_attributes)
+    end
+  end
+
+
 end

--- a/spec/paymill/subscription_spec.rb
+++ b/spec/paymill/subscription_spec.rb
@@ -3,14 +3,14 @@ require "spec_helper"
 describe Paymill::Subscription do
   let(:valid_attributes) do
     {
-      plan: {
+      plan:                 {
         name:     "Nerd special",
         amount:   123,
         interval: "week"
       },
-      livemode: false,
+      livemode:             false,
       cancel_at_period_end: false,
-      client: {
+      client:               {
         email: "stefan.sprenger@dkd.de"
       }
     }
@@ -61,12 +61,18 @@ describe Paymill::Subscription do
 
   describe "#update" do
     it "makes a new PUT request using the correct API endpoint" do
-      changed_attributes = { :cancel_at_period_end => true }
-      subscription.id = 'sub_123'
+      changed_attributes = {:cancel_at_period_end => true}
+      subscription.id    = 'sub_123'
 
-      Paymill.should_receive(:request).with(:put, "subscriptions/sub_123", changed_attributes).and_return("data" => {})
+      Paymill.should_receive(:request).with(:put, "subscriptions/sub_123", changed_attributes).and_return("data" => changed_attributes)
 
       subscription.update(changed_attributes)
+    end
+
+    it "should set the returned attributes on the instance" do
+      Paymill.should_receive(:request).and_return("data" => {:cancel_at_period_end => true})
+      subscription.update({})
+      subscription.cancel_at_period_end.should be_true
     end
   end
 


### PR DESCRIPTION
I have a added a simple way of updating instances of `Client`, `Offer` and `Subscription`. It creates the put request and just merges the attributes of the resulting data back to the instance. 

``` ruby
client = Paymill::Client.find("client_88a388d9dd48f86c3136")
client.update(:email => "carl.client@example.com")
```

would update the email address of `client`only if it was returned in the response.
