### PR TITLE
Add ability to pass sort and filter parameters to the 'all' method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem "rspec"
 gem "rake"
+gem "webmock"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ operation:
 
     Paymill::Client.all
 
+To sort and filter collection lists of objects, use the `all` method
+with an options hash. For example to find the most recent transactions
+belonging to a client:
+    
+    Paymill::Transaction.all({client: "client_id", order: "created_at_desc"})
+
 Please note that Transactions and Payments cannot be updated.
 
 Requirements

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -50,15 +50,15 @@ module Paymill
       https.start do |connection|
         url = "/#{API_VERSION}/#{api_url}"
         https_request = case http_method
-              when :post
-                Net::HTTP::Post.new(url)
-              when :put
-                Net::HTTP::Put.new(url)
-              when :delete
-                Net::HTTP::Delete.new(url)
-              else
-                Net::HTTP::Get.new(url)
-              end
+                        when :post
+                          Net::HTTP::Post.new(url)
+                        when :put
+                          Net::HTTP::Put.new(url)
+                        when :delete
+                          Net::HTTP::Delete.new(url)
+                        else
+                          Net::HTTP::Get.new(path_with_params(url, data))
+                        end
         https_request.basic_auth(api_key, "")
         https_request.set_form_data(data) if [:post, :put].include? http_method
         @response = https.request(https_request)
@@ -70,6 +70,11 @@ module Paymill
       raise APIError.new(data["error"]) if data["error"]
 
       data
+    end
+
+    def path_with_params(path, params)
+      encoded_params = URI.encode_www_form(params)
+      [path, encoded_params].join("?")
     end
   end
 end

--- a/lib/paymill/operations/all.rb
+++ b/lib/paymill/operations/all.rb
@@ -2,8 +2,8 @@ module Paymill
   module Operations
     module All
       module ClassMethods
-        def all
-          response = Paymill.request(:get, "#{self.name.split("::").last.downcase}s/", {})
+        def all(sort_and_filter_options={})
+          response = Paymill.request(:get, "#{self.name.split("::").last.downcase}s/", sort_and_filter_options)
           results = []
           response["data"].each do |obj|
             results << self.new(obj)

--- a/spec/paymill/transaction_spec.rb
+++ b/spec/paymill/transaction_spec.rb
@@ -47,6 +47,13 @@ describe Paymill::Transaction do
     end
   end
 
+  describe ".all with options" do
+    it "makes a new GET request using the correct API endpoint to receive all transactions" do
+      Paymill.should_receive(:request).with(:get, "transactions/", {client: "client_id"}).and_return("data" => {})
+      Paymill::Transaction.all(client: "client_id")
+    end
+  end
+
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
       Paymill.should_receive(:request).with(:post, "transactions", valid_attributes).and_return("data" => {})

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -7,5 +7,19 @@ describe Paymill do
         expect { Paymill.request(:get, "clients", {}) }.to raise_error(Paymill::AuthenticationError)
       end
     end
+    context "with an invalid api key" do
+      before(:each) do
+        WebMock.stub_request(:any, /#{Paymill::API_BASE}/).to_return(:body => "{}")
+        Paymill.api_key = "your-api-key"
+      end
+      it "attempts to get a url with one param" do
+        Paymill.request(:get, "transactions", {param_name: "param_value"})
+        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::API_BASE}/#{Paymill::API_VERSION}/transactions?param_name=param_value")
+      end
+      it "attempts to get a url with more than one param" do
+        Paymill.request(:get, "transactions", {client: "client_id", order: "created_at_desc"})
+        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::API_BASE}/#{Paymill::API_VERSION}/transactions?client=client_id&order=created_at_desc")
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'paymill'
 require 'rspec'
 require 'rspec/autorun'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
 end


### PR DESCRIPTION
A possible solution for issue #11.

Allow a hash of options to be passed to the `all` method. This means we can use [Paymill's listviews sort and filter options](https://www.paymill.com/de-de/dokumentation/referenz/api-referenz/index.html#listviews) when returning lists of objects.

For example to find the most recent transactions belonging to a client we can do:

```
Paymill::Transaction.all({client: "client_id", order: "created_at_desc"})
```
