### PR TITLE
use singleton_class on base to create attr_accesors for all attributes

### DIFF
--- a/lib/paymill/base.rb
+++ b/lib/paymill/base.rb
@@ -15,6 +15,11 @@ module Paymill
       attributes.each_pair do |key, value|
         instance_variable_set("@#{key}", value)
       end
+      singleton_class.class_eval do
+        attributes.each_key do |key|
+          attr_accessor key
+        end
+      end
     end
 
     def parse_timestamps


### PR DESCRIPTION
This change automatically adds attr_accessor for all attributes
