### PR TITLE
Make subscription payment available through Subscription#payment

### DIFF
--- a/lib/paymill/subscription.rb
+++ b/lib/paymill/subscription.rb
@@ -4,7 +4,7 @@ module Paymill
     include Paymill::Operations::Update
 
     attr_accessor :id, :offer, :livemode, :cancel_at_period_end, :canceled_at, :client,
-                  :trial_start, :trial_end, :next_capture_at
+                  :trial_start, :trial_end, :next_capture_at, :payment
 
     # Parses UNIX timestamps and creates Time objects
     def parse_timestamps

--- a/spec/paymill/subscription_spec.rb
+++ b/spec/paymill/subscription_spec.rb
@@ -15,6 +15,9 @@ describe Paymill::Subscription do
       cancel_at_period_end: false,
       client:               {
         email: "stefan.sprenger@dkd.de"
+      },
+      payment:              {
+        id: "pay_3af44644dd6d25c820a8",
       }
     }
   end
@@ -31,6 +34,7 @@ describe Paymill::Subscription do
       subscription.livemode.should be_false
       subscription.cancel_at_period_end.should be_false
       subscription.client[:email].should eql("stefan.sprenger@dkd.de")
+      subscription.payment[:id].should eql("pay_3af44644dd6d25c820a8")
       subscription.trial_start.to_i.should eql(1349945681)
       subscription.trial_end.to_i.should eql(1349945682)
     end


### PR DESCRIPTION
This commit grants access to another missing field in the subscription (besides the `next_capture_at` field on #24): the payment. Both fields are needed so you don't have to access subscription data via meta-programming, like you have to do right now:

``` ruby
#...
data = {
  next_payment_at:  subscription.instance_variable_get('@next_capture_at'),
  card_type:        subscription.instance_variable_get('@payment')['card_type'],
  expiration_month: subscription.instance_variable_get('@payment')['expire_month'],
  expiration_year:  subscription.instance_variable_get('@payment')['expire_year']
}
```
