### PR TITLE
Add origin_amount as accessible attribute to transaction

### DIFF
--- a/lib/paymill/transaction.rb
+++ b/lib/paymill/transaction.rb
@@ -1,6 +1,7 @@
 module Paymill
   class Transaction < Base
     attr_accessor :id, :amount, :status, :description, :livemode,
-                  :payment, :currency, :client, :response_code
+                  :payment, :currency, :client, :response_code,
+                  :origin_amount
   end
 end

--- a/spec/paymill/transaction_spec.rb
+++ b/spec/paymill/transaction_spec.rb
@@ -4,6 +4,7 @@ describe Paymill::Transaction do
   let(:valid_attributes) do
     {
       amount: 4200,
+      origin_amount: 4200,
       currency: "EUR",
       status: "pending",
       description: "Test transaction.",
@@ -24,6 +25,7 @@ describe Paymill::Transaction do
   describe "#initialize" do
     it "initializes all attributes correctly" do
       transaction.amount.should eql(4200)
+      transaction.origin_amount.should eql(4200)
       transaction.status.should eql("pending")
       transaction.description.should eql("Test transaction.")
       transaction.livemode.should eql(false)


### PR DESCRIPTION
When issuing refunds on a transaction, the amount will be a composite of the originally charged amount minus the refunded amount. It would be nice to have `origin_amount` available to see the originally charged amount.
