### PR TITLE
Add info on refunds to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,24 @@ Retrieving all webhooks:
     Paymill::Webhook.all
 
 
+Refunds
+------
+
+*[Paymill documentation on refunds](https://www.paymill.com/en-gb/documentation-3/reference/api-reference/#refunds)*
+
+Creating a new refund:
+
+    Paymill::Refund.create(id: "tran_023d3b5769321c649435", amount: 4200)
+
+Retrieving a refund:
+
+    refund = Paymill::Refund.find("refund_87bc404a95d5ce616049")
+
+Retrieving all refunds:
+
+    Paymill::Refund.all
+
+
 Requirements
 =====
 


### PR DESCRIPTION
Creating a refund wasn't self-explanatory as it differs from creating other objects against the Paymill API. As it turns out the transaction-id either has to be part of the URL (pain with this gem) or it can be submitted as an `id`-parameter. I've added info to the readme on how to do the latter.
