### PR TITLE
Better configuration for Paymill gem

### DIFF
--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -9,6 +9,9 @@ module Paymill
   ROOT_PATH   = File.dirname(__FILE__)
 
   @@api_key = nil
+  @@api_base = API_BASE
+  @@api_version = API_VERSION
+  @@api_port = Net::HTTP.https_default_port
 
   autoload :Base,             "paymill/base"
   autoload :Client,           "paymill/client"
@@ -40,7 +43,7 @@ module Paymill
   class AuthenticationError < PaymillError; end
   class APIError            < PaymillError; end
 
-  # Returns the set api key
+  # Returns the api key
   #
   # @return [String] The api key
   def self.api_key
@@ -52,6 +55,48 @@ module Paymill
   # @param [String] api_key The api key
   def self.api_key=(api_key)
     @@api_key = api_key
+  end
+
+  # Returns the api base endpoint
+  #
+  # @return [String] The api base endpoint
+  def self.api_base
+    @@api_base
+  end
+
+  # Sets the api base endpoint
+  #
+  # @param [String] api_base The api base endpoint
+  def self.api_base=(api_base)
+    @@api_base = api_base
+  end
+
+  # Returns the api version
+  #
+  # @return [String] The api version
+  def self.api_version
+    @@api_version
+  end
+
+  # Sets the api version
+  #
+  # @param [String] api_version The api version
+  def self.api_version=(api_version)
+    @@api_version = api_version
+  end
+
+  # Returns the api port
+  #
+  # @return [String] The api port
+  def self.api_port
+    @@api_port
+  end
+
+  # Sets the api port
+  #
+  # @param [String] api_port The api port
+  def self.api_port=(api_port)
+    @@api_port = api_port
   end
 
   # Makes a request against the Paymill API

--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -12,6 +12,7 @@ module Paymill
   @@api_base = API_BASE
   @@api_version = API_VERSION
   @@api_port = Net::HTTP.https_default_port
+  @@development = false
 
   autoload :Base,             "paymill/base"
   autoload :Client,           "paymill/client"
@@ -97,6 +98,20 @@ module Paymill
   # @param [String] api_port The api port
   def self.api_port=(api_port)
     @@api_port = api_port
+  end
+
+  # Returns true if the development mode is on
+  #
+  # @return [Boolean] Development mode on or not
+  def self.development?
+    @@development
+  end
+
+  # Sets the development mode
+  #
+  # @param [Boolean] development Development mode on or not
+  def self.development=(development)
+    @@development = development
   end
 
   # Makes a request against the Paymill API

--- a/lib/paymill/request/connection.rb
+++ b/lib/paymill/request/connection.rb
@@ -9,7 +9,7 @@ module Paymill
       end
 
       def setup_https
-        @https             = Net::HTTP.new(API_BASE, Net::HTTP.https_default_port)
+        @https             = Net::HTTP.new(Paymill.api_base, Paymill.api_port)
         @https.use_ssl     = true
         @https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         @https.ca_file     = File.join(ROOT_PATH, "data/paymill.crt")

--- a/lib/paymill/request/connection.rb
+++ b/lib/paymill/request/connection.rb
@@ -10,9 +10,11 @@ module Paymill
 
       def setup_https
         @https             = Net::HTTP.new(Paymill.api_base, Paymill.api_port)
-        @https.use_ssl     = true
-        @https.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        @https.ca_file     = File.join(ROOT_PATH, "data/paymill.crt")
+        unless Paymill.development?
+          @https.use_ssl     = true
+          @https.verify_mode = OpenSSL::SSL::VERIFY_PEER
+          @https.ca_file     = File.join(ROOT_PATH, "data/paymill.crt")
+        end
       end
 
       def request

--- a/lib/paymill/request/info.rb
+++ b/lib/paymill/request/info.rb
@@ -10,7 +10,7 @@ module Paymill
       end
 
       def url
-        url = "/#{API_VERSION}/#{api_url}"
+        url = "/#{Paymill.api_version}/#{api_url}"
         if is_refund?
           url += "/#{data[:id]}"
           data.delete(:id)

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -10,23 +10,23 @@ describe Paymill do
 
     context "with an invalid api key" do
       before(:each) do
-        WebMock.stub_request(:any, /#{Paymill::API_BASE}/).to_return(:body => "{}")
+        WebMock.stub_request(:any, /#{Paymill.api_base}/).to_return(:body => "{}")
         Paymill.api_key = "your-api-key"
       end
 
       it "attempts to get a url with one param" do
         Paymill.request(:get, "transactions", { param_name: "param_value" })
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::API_BASE}/#{Paymill::API_VERSION}/transactions?param_name=param_value")
+        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?param_name=param_value")
       end
 
       it "attempts to get a url with more than one param" do
         Paymill.request(:get, "transactions", { client: "client_id", order: "created_at_desc" })
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::API_BASE}/#{Paymill::API_VERSION}/transactions?client=client_id&order=created_at_desc")
+        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?client=client_id&order=created_at_desc")
       end
 
       it "doesn't add a question mark if no params" do
         Paymill.request(:get, "transactions", {})
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::API_BASE}/#{Paymill::API_VERSION}/transactions")
+        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions")
       end
     end
   end


### PR DESCRIPTION
- Allows configuration of base endpoint, port, version and adds a
  development mode
- Creates a Paymill::Configuration class for all configs
- Deprecates Paymill.api_key and Paymill.api_key=
- Updates README
