### PR TITLE
Let the api handle authentication errors

### DIFF
--- a/lib/paymill/request/base.rb
+++ b/lib/paymill/request/base.rb
@@ -9,7 +9,6 @@ module Paymill
       end
 
       def perform
-        raise AuthenticationError if Paymill.api_key.nil?
         connection.setup_https
         send_request
 

--- a/spec/paymill/request/base_spec.rb
+++ b/spec/paymill/request/base_spec.rb
@@ -2,14 +2,6 @@ require "spec_helper"
 
 describe Paymill::Request::Base do
   context "#perform" do
-    it "checks for an api key" do
-      Paymill.stub(:api_key).and_return(nil)
-
-      expect{
-        Paymill::Request::Base.new(nil).perform
-      }.to raise_error Paymill::AuthenticationError
-    end
-
     it "performs an https request" do
       Paymill.stub(:api_key).and_return("some key")
       connection = double

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -4,6 +4,7 @@ describe Paymill do
   describe ".request" do
     context "given no api key exists" do
       it "raises an authentication error" do
+        WebMock.stub_request(:get, /#{Paymill.api_base}/).to_return(:body => "{}", :status => 401)
         expect { Paymill.request(:get, "clients", {}) }.to raise_error(Paymill::AuthenticationError)
       end
     end


### PR DESCRIPTION
Hi partypeople,

First, thanks for this gem. We're currently moving from another payment provider to paymill and it feels really good to have such a nice gem available. Keep up the good work! :shipit: 

When I started to develop with this gem, I noticed this behaviour: If you don't set an api key, then everything else gets bypassed and the gem throws an error. :scream_cat: [[1](https://github.com/dkd/paymill-ruby/blob/master/lib/paymill/request/base.rb#L12)]

It feels kind of unexpected and strange for me, because
1. The Paymill api will handle it anyway and should responsible for deciding if a request is authenticated or not
2. The gem will handle an unauthenticated response and throws the error anyway [[2](https://github.com/dkd/paymill-ruby/blob/master/lib/paymill/request/validator.rb#L22)]
3. When testing our application, we have to take care of providing some api key which does nothing in the end
4. Especially when using VCR (or something else) for matching and replaying requests, its much more convenient to not care about setting an api key

Probably I dont get the point here and you guys have some good reasons for doing this, otherwise I would love to see this merged. As far as I can see it will not break any compatibilities, because it will just throw the same error just a bit later.

:sparkling_heart: :sparkling_heart: :sparkling_heart: Thanks, :sparkling_heart: :sparkling_heart: :sparkling_heart: 

ben
