### PR TITLE
Expose to_h method for paymill objects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rspec", "2.14.0"
+gem "rspec", "3.0.0"
 gem "rake"
 gem "webmock"
 gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rspec"
+gem "rspec", "2.14.0"
 gem "rake"
 gem "webmock"
 gem "pry"

--- a/lib/paymill/base.rb
+++ b/lib/paymill/base.rb
@@ -14,10 +14,16 @@ module Paymill
       parse_timestamps
     end
 
+    # Returns the attributes hash set via #set_attributes
+    def to_h
+      @attributes
+    end
+
     # Sets the attributes
     #
     # @param [Hash] attributes The attributes to initialize
     def set_attributes(attributes)
+      @attributes = attributes
       attributes.each_pair do |key, value|
         instance_variable_set("@#{key}", value)
       end

--- a/spec/paymill/base_spec.rb
+++ b/spec/paymill/base_spec.rb
@@ -11,14 +11,14 @@ describe Paymill::Base do
     context "given #created_at is present" do
       it "creates a Time object" do
         base = Paymill::Base.new(created_at: 1362823928)
-        base.created_at.class.should eql(Time)
+        expect(base.created_at.class).to eql(Time)
       end
     end
 
     context "given #updated_at is present" do
       it "creates a Time object" do
         base = Paymill::Base.new(updated_at: 1362823928)
-        base.updated_at.class.should eql(Time)
+        expect(base.updated_at.class).to eql(Time)
       end
     end
   end

--- a/spec/paymill/base_spec.rb
+++ b/spec/paymill/base_spec.rb
@@ -1,6 +1,12 @@
 require "spec_helper"
 
 describe Paymill::Base do
+  it "can be converted to a ruby hash" do
+    attributes = { id: "some id", created_at: 1362823928 }
+    base = Paymill::Base.new(attributes)
+    expect(base.to_h).to be == attributes
+  end
+
   describe "#parse_timestamps" do
     context "given #created_at is present" do
       it "creates a Time object" do

--- a/spec/paymill/client_spec.rb
+++ b/spec/paymill/client_spec.rb
@@ -11,35 +11,35 @@ describe Paymill::Client do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      client.email.should eql("stefan.sprenger@dkd.de")
-      client.description.should eql("First customer.")
+      expect(client.email).to eql("stefan.sprenger@dkd.de")
+      expect(client.description).to eql("First customer.")
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific client" do
-      Paymill.should_receive(:request).with(:get, "clients/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "clients/123", {}).and_return("data" => {})
       Paymill::Client.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all clients" do
-      Paymill.should_receive(:request).with(:get, "clients/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "clients/", {}).and_return("data" => {})
       Paymill::Client.all
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "clients/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "clients/123", {}).and_return(true)
       Paymill::Client.delete("123")
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "clients", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "clients", valid_attributes).and_return("data" => {})
       Paymill::Client.create(valid_attributes)
     end
   end
@@ -47,17 +47,17 @@ describe Paymill::Client do
   describe "#update_attributes" do
     it "makes a new PUT request using the correct API endpoint" do
       client.id = "client_123"
-      Paymill.should_receive(:request).with(:put, "clients/client_123", {:email => "tim.test@exmaple.com"}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:put, "clients/client_123", {:email => "tim.test@exmaple.com"}).and_return("data" => {})
 
       client.update_attributes({:email => "tim.test@exmaple.com"})
     end
 
     it "updates the instance with the returned attributes" do
       changed_attributes = {:email => "tim.test@example.com"}
-      Paymill.should_receive(:request).and_return("data" => changed_attributes)
+      expect(Paymill).to receive(:request).and_return("data" => changed_attributes)
       client.update_attributes(changed_attributes)
 
-      client.email.should eql("tim.test@example.com")
+      expect(client.email).to eql("tim.test@example.com")
     end
   end
 end

--- a/spec/paymill/offer_spec.rb
+++ b/spec/paymill/offer_spec.rb
@@ -16,37 +16,37 @@ describe Paymill::Offer do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      offer.amount.should eql(4200)
-      offer.currency.should eql("eur")
-      offer.interval.should eql("month")
-      offer.name.should eql("Medium Plan")
+      expect(offer.amount).to eql(4200)
+      expect(offer.currency).to eql("eur")
+      expect(offer.interval).to eql("month")
+      expect(offer.name).to eql("Medium Plan")
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific offer" do
-      Paymill.should_receive(:request).with(:get, "offers/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "offers/123", {}).and_return("data" => {})
       Paymill::Offer.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all offers" do
-      Paymill.should_receive(:request).with(:get, "offers/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "offers/", {}).and_return("data" => {})
       Paymill::Offer.all
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "offers/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "offers/123", {}).and_return(true)
       Paymill::Offer.delete("123")
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "offers", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "offers", valid_attributes).and_return("data" => {})
       Paymill::Offer.create(valid_attributes)
     end
   end
@@ -54,17 +54,17 @@ describe Paymill::Offer do
   describe "#update_attributes" do
     it "makes a new PUT request using the correct API endpoint" do
       offer.id = "offer_123"
-      Paymill.should_receive(:request).with(:put, "offers/offer_123", {:name => "Large Plan"}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:put, "offers/offer_123", {:name => "Large Plan"}).and_return("data" => {})
 
       offer.update_attributes({:name => "Large Plan"})
     end
 
     it "updates the instance with the returned attributes" do
       changed_attributes = {:name => "Large Plan"}
-      Paymill.should_receive(:request).and_return("data" => changed_attributes)
+      expect(Paymill).to receive(:request).and_return("data" => changed_attributes)
       offer.update_attributes(changed_attributes)
 
-      offer.name.should eql("Large Plan")
+      expect(offer.name).to eql("Large Plan")
     end
   end
 end

--- a/spec/paymill/payment_spec.rb
+++ b/spec/paymill/payment_spec.rb
@@ -18,39 +18,39 @@ describe Paymill::Payment do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      payment.card_type.should eql("visa")
-      payment.country.should eql("germany")
-      payment.expire_month.should eql(12)
-      payment.expire_year.should eq(2012)
-      payment.card_holder.should eql("Stefan Sprenger")
-      payment.last4.should eql("1111")
+      expect(payment.card_type).to eql("visa")
+      expect(payment.country).to eql("germany")
+      expect(payment.expire_month).to eql(12)
+      expect(payment.expire_year).to eq(2012)
+      expect(payment.card_holder).to eql("Stefan Sprenger")
+      expect(payment.last4).to eql("1111")
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific creditcard" do
-      Paymill.should_receive(:request).with(:get, "payments/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "payments/123", {}).and_return("data" => {})
       Paymill::Payment.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all payments" do
-      Paymill.should_receive(:request).with(:get, "payments/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "payments/", {}).and_return("data" => {})
       Paymill::Payment.all
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "payments", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "payments", valid_attributes).and_return("data" => {})
       Paymill::Payment.create(valid_attributes)
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "payments/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "payments/123", {}).and_return(true)
       Paymill::Payment.delete("123")
     end
   end

--- a/spec/paymill/preauthorization_spec.rb
+++ b/spec/paymill/preauthorization_spec.rb
@@ -15,22 +15,22 @@ describe Paymill::Preauthorization do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      preauthorization.payment.should eql("pay_d43cf0ee969d9847512b")
-      preauthorization.amount.should eql(4200)
-      preauthorization.currency.should eql("EUR")
+      expect(preauthorization.payment).to eql("pay_d43cf0ee969d9847512b")
+      expect(preauthorization.amount).to eql(4200)
+      expect(preauthorization.currency).to eql("EUR")
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "preauthorizations", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "preauthorizations", valid_attributes).and_return("data" => {})
       Paymill::Preauthorization.create(valid_attributes)
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "preauthorizations/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "preauthorizations/123", {}).and_return(true)
       Paymill::Preauthorization.delete("123")
     end
   end

--- a/spec/paymill/refund_spec.rb
+++ b/spec/paymill/refund_spec.rb
@@ -64,11 +64,11 @@ describe Paymill::Refund do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      refund.id.should eql("refund_87bc404a95d5ce616049")
-      refund.amount.should eql("042")
-      refund.status.should eql("refunded")
-      refund.description.should be_nil
-      refund.livemode.should be_false
+      expect(refund.id).to eql("refund_87bc404a95d5ce616049")
+      expect(refund.amount).to eql("042")
+      expect(refund.status).to eql("refunded")
+      expect(refund.description).to be_nil
+      expect(refund.livemode).to be false
 =begin
       refund.transaction[:refunds].should eql(
         [
@@ -113,7 +113,7 @@ describe Paymill::Refund do
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "refunds", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "refunds", valid_attributes).and_return("data" => {})
       Paymill::Refund.create(valid_attributes)
     end
   end

--- a/spec/paymill/request/base_spec.rb
+++ b/spec/paymill/request/base_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 describe Paymill::Request::Base do
   context "#perform" do
     it "performs an https request" do
-      Paymill.stub(:api_key).and_return("some key")
+      allow(Paymill).to receive(:api_key).and_return("some key")
       connection = double
       validator  = double
-      Paymill::Request::Connection.stub(:new).and_return(connection)
-      Paymill::Request::Validator.stub(:new).and_return(validator)
+      allow(Paymill::Request::Connection).to receive(:new).and_return(connection)
+      allow(Paymill::Request::Validator).to receive(:new).and_return(validator)
 
-      connection.should_receive(:setup_https)
-      connection.should_receive(:request)
-      validator.should_receive(:validated_data_for)
+      expect(connection).to receive(:setup_https)
+      expect(connection).to receive(:request)
+      expect(validator).to receive(:validated_data_for)
 
       Paymill::Request::Base.new(nil).perform
     end

--- a/spec/paymill/request/connection_spec.rb
+++ b/spec/paymill/request/connection_spec.rb
@@ -7,7 +7,7 @@ describe Paymill::Request::Connection do
 
       connection.setup_https
 
-      connection.https.should_not be_nil
+      expect(connection.https).not_to be_nil
     end
   end
 
@@ -15,9 +15,9 @@ describe Paymill::Request::Connection do
     it "performs the actual request" do
       connection = Paymill::Request::Connection.new(nil)
       connection.setup_https
-      connection.stub(:https_request)
+      allow(connection).to receive(:https_request)
 
-      connection.https.should_receive(:request)
+      expect(connection.https).to receive(:request)
 
       connection.request
     end
@@ -26,10 +26,10 @@ describe Paymill::Request::Connection do
       info = double(http_method: :post, url: "/some/path", data: params)
       connection = Paymill::Request::Connection.new(info)
       connection.setup_https
-      connection.stub(:https_request)
-      connection.https.stub(:request).and_return(double(code: 200))
+      allow(connection).to receive(:https_request)
+      allow(connection.https).to receive(:request).and_return(double(code: 200))
 
-      Paymill.logger.should_receive(:info)
+      expect(Paymill.logger).to receive(:info)
 
       connection.request
     end
@@ -41,7 +41,7 @@ describe Paymill::Request::Connection do
       connection = Paymill::Request::Connection.new(info)
       connection.setup_https
 
-      connection.__send__(:https_request).body.downcase.should eq("email=abc_abc.com&event_types%5b0%5d=transaction.created&event_types%5b1%5d=transaction.failed&event_types%5b2%5d=refund.created&event_types%5b3%5d=invoice.available")
+      expect(connection.__send__(:https_request).body.downcase).to eq("email=abc_abc.com&event_types%5b0%5d=transaction.created&event_types%5b1%5d=transaction.failed&event_types%5b2%5d=refund.created&event_types%5b3%5d=invoice.available")
     end
   end
 

--- a/spec/paymill/request/info_spec.rb
+++ b/spec/paymill/request/info_spec.rb
@@ -5,7 +5,7 @@ describe Paymill::Request::Info do
     it "constructs the url" do
       info = Paymill::Request::Info.new(:get, "random", OpenStruct.new(id: 1))
 
-      info.url.should =~ /random/
+      expect(info.url).to match(/random/)
     end
   end
 
@@ -14,14 +14,14 @@ describe Paymill::Request::Info do
       info = Paymill::Request::Info.new(:get, "random", nil)
       path = "/path/to/someplace"
 
-      info.path_with_params(path, {}).should eq path
+      expect(info.path_with_params(path, {})).to eq path
     end
 
     it "constructs the path with params" do
       info = Paymill::Request::Info.new(:get, "random", nil)
       path = "/path/to/someplace"
 
-      info.path_with_params(path, {random: "stuff"}).should eq "#{path}?random=stuff"
+      expect(info.path_with_params(path, {random: "stuff"})).to eq "#{path}?random=stuff"
     end
   end
 end

--- a/spec/paymill/request/validator_spec.rb
+++ b/spec/paymill/request/validator_spec.rb
@@ -7,7 +7,7 @@ describe Paymill::Request::Validator do
       validator = Paymill::Request::Validator.new info
       response = OpenStruct.new(body: '{"response":"ok"}', code: 200)
 
-      validator.validated_data_for(response).should eq "response" => "ok"
+      expect(validator.validated_data_for(response)).to eq "response" => "ok"
     end
   end
 end

--- a/spec/paymill/subscription_spec.rb
+++ b/spec/paymill/subscription_spec.rb
@@ -28,15 +28,15 @@ describe Paymill::Subscription do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      subscription.offer[:name].should eql("Nerd special")
-      subscription.offer[:amount].should eql(123)
-      subscription.offer[:interval].should eql("week")
-      subscription.livemode.should be_false
-      subscription.cancel_at_period_end.should be_false
-      subscription.client[:email].should eql("stefan.sprenger@dkd.de")
-      subscription.payment[:id].should eql("pay_3af44644dd6d25c820a8")
-      subscription.trial_start.to_i.should eql(1349945681)
-      subscription.trial_end.to_i.should eql(1349945682)
+      expect(subscription.offer[:name]).to eql("Nerd special")
+      expect(subscription.offer[:amount]).to eql(123)
+      expect(subscription.offer[:interval]).to eql("week")
+      expect(subscription.livemode).to be false
+      expect(subscription.cancel_at_period_end).to be false
+      expect(subscription.client[:email]).to eql("stefan.sprenger@dkd.de")
+      expect(subscription.payment[:id]).to eql("pay_3af44644dd6d25c820a8")
+      expect(subscription.trial_start.to_i).to eql(1349945681)
+      expect(subscription.trial_end.to_i).to eql(1349945682)
     end
   end
 
@@ -44,63 +44,63 @@ describe Paymill::Subscription do
     context "given #canceled_at is present" do
       it "creates a Time object" do
         subscription = Paymill::Subscription.new(canceled_at: 1362823928)
-        subscription.canceled_at.class.should eql(Time)
+        expect(subscription.canceled_at.class).to eql(Time)
       end
     end
 
     context "given #trial_start is present" do
       it "creates a Time object" do
         subscription = Paymill::Subscription.new(trial_start: 1362823928)
-        subscription.trial_start.class.should eql(Time)
+        expect(subscription.trial_start.class).to eql(Time)
       end
     end
 
     context "given #trial_end is present" do
       it "creates a Time object" do
         subscription = Paymill::Subscription.new(trial_end: 1362823928)
-        subscription.trial_end.class.should eql(Time)
+        expect(subscription.trial_end.class).to eql(Time)
       end
     end
 
     context "given #next_capture_at is present" do
       it "creates a Time object" do
         subscription = Paymill::Subscription.new(next_capture_at: 1362823928)
-        subscription.next_capture_at.class.should eql(Time)
+        expect(subscription.next_capture_at.class).to eql(Time)
       end
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific subscription" do
-      Paymill.should_receive(:request).with(:get, "subscriptions/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "subscriptions/123", {}).and_return("data" => {})
       Paymill::Subscription.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all subscriptions" do
-      Paymill.should_receive(:request).with(:get, "subscriptions/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "subscriptions/", {}).and_return("data" => {})
       Paymill::Subscription.all
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "subscriptions/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "subscriptions/123", {}).and_return(true)
       Paymill::Subscription.delete("123")
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "subscriptions", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "subscriptions", valid_attributes).and_return("data" => {})
       Paymill::Subscription.create(valid_attributes)
     end
   end
 
   describe ".update_attributes" do
     it "makes a new PUT request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:put, "subscriptions/sub_123", {:offer => 50 }).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:put, "subscriptions/sub_123", {:offer => 50 }).and_return("data" => {})
       Paymill::Subscription.update_attributes("sub_123", {:offer => 50 })
     end
   end
@@ -110,15 +110,15 @@ describe Paymill::Subscription do
       changed_attributes = {:cancel_at_period_end => true}
       subscription.id    = "sub_123"
 
-      Paymill.should_receive(:request).with(:put, "subscriptions/sub_123", changed_attributes).and_return("data" => changed_attributes)
+      expect(Paymill).to receive(:request).with(:put, "subscriptions/sub_123", changed_attributes).and_return("data" => changed_attributes)
 
       subscription.update_attributes(changed_attributes)
     end
 
     it "should set the returned attributes on the instance" do
-      Paymill.should_receive(:request).and_return("data" => {:cancel_at_period_end => true})
+      expect(Paymill).to receive(:request).and_return("data" => {:cancel_at_period_end => true})
       subscription.update_attributes({})
-      subscription.cancel_at_period_end.should be_true
+      expect(subscription.cancel_at_period_end).to be true
     end
   end
 end

--- a/spec/paymill/transaction_spec.rb
+++ b/spec/paymill/transaction_spec.rb
@@ -27,47 +27,47 @@ describe Paymill::Transaction do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      transaction.amount.should eql(4200)
-      transaction.origin_amount.should eql(4200)
-      transaction.status.should eql("pending")
-      transaction.description.should eql("Test transaction.")
-      transaction.livemode.should eql(false)
-      transaction.response_code.should eql(20000)
-      transaction.payment[:card_type].should eql("visa")
-      transaction.payment[:country].should eql("germany")
-      transaction.client.should eql("client_a013c")
-      transaction.currency.should eql("EUR")
-      transaction.refunds.should_not be_nil
-      transaction.refunds.should_not be_empty
-      transaction.refunds.first.should_not be_nil
-      transaction.refunds.first[:id].should eql("refund_abc")
+      expect(transaction.amount).to eql(4200)
+      expect(transaction.origin_amount).to eql(4200)
+      expect(transaction.status).to eql("pending")
+      expect(transaction.description).to eql("Test transaction.")
+      expect(transaction.livemode).to eql(false)
+      expect(transaction.response_code).to eql(20000)
+      expect(transaction.payment[:card_type]).to eql("visa")
+      expect(transaction.payment[:country]).to eql("germany")
+      expect(transaction.client).to eql("client_a013c")
+      expect(transaction.currency).to eql("EUR")
+      expect(transaction.refunds).not_to be_nil
+      expect(transaction.refunds).not_to be_empty
+      expect(transaction.refunds.first).not_to be_nil
+      expect(transaction.refunds.first[:id]).to eql("refund_abc")
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific transaction" do
-      Paymill.should_receive(:request).with(:get, "transactions/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "transactions/123", {}).and_return("data" => {})
       Paymill::Transaction.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all transactions" do
-      Paymill.should_receive(:request).with(:get, "transactions/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "transactions/", {}).and_return("data" => {})
       Paymill::Transaction.all
     end
   end
 
   describe ".all with options" do
     it "makes a new GET request using the correct API endpoint to receive all transactions" do
-      Paymill.should_receive(:request).with(:get, "transactions/", { client: "client_id" }).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "transactions/", { client: "client_id" }).and_return("data" => {})
       Paymill::Transaction.all(client: "client_id")
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "transactions", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "transactions", valid_attributes).and_return("data" => {})
       Paymill::Transaction.create(valid_attributes)
     end
   end
@@ -75,17 +75,17 @@ describe Paymill::Transaction do
   describe "#update_attributes" do
     it "makes a new PUT request using the correct API endpoint" do
       transaction.id = "trans_123"
-      Paymill.should_receive(:request).with(:put, "transactions/trans_123", {:description => "Transaction Description"}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:put, "transactions/trans_123", {:description => "Transaction Description"}).and_return("data" => {})
 
       transaction.update_attributes({:description => "Transaction Description"})
     end
 
     it "updates the instance with the returned attributes" do
       changed_attributes = {:description => "Transaction Description"}
-      Paymill.should_receive(:request).and_return("data" => changed_attributes)
+      expect(Paymill).to receive(:request).and_return("data" => changed_attributes)
       transaction.update_attributes(changed_attributes)
 
-      transaction.description.should eql("Transaction Description")
+      expect(transaction.description).to eql("Transaction Description")
     end
   end
 end

--- a/spec/paymill/webhook_spec.rb
+++ b/spec/paymill/webhook_spec.rb
@@ -17,38 +17,38 @@ describe Paymill::Webhook do
 
   describe "#initialize" do
     it "initializes all attributes correctly" do
-      webhook.url.should eql("<your-webhook-url>")
-      webhook.livemode.should eql(false)
-      webhook.event_types.should eql(["transaction.succeeded","transaction.failed"])   
-      webhook.created_at.to_i.should eql(1360368749)
-      webhook.updated_at.to_i.should eql(1360368749)
+      expect(webhook.url).to eql("<your-webhook-url>")
+      expect(webhook.livemode).to eql(false)
+      expect(webhook.event_types).to eql(["transaction.succeeded","transaction.failed"])   
+      expect(webhook.created_at.to_i).to eql(1360368749)
+      expect(webhook.updated_at.to_i).to eql(1360368749)
     end
   end
 
   describe ".find" do
     it "makes a new GET request using the correct API endpoint to receive a specific webhook" do
-      Paymill.should_receive(:request).with(:get, "webhooks/123", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "webhooks/123", {}).and_return("data" => {})
       Paymill::Webhook.find("123")
     end
   end
 
   describe ".all" do
     it "makes a new GET request using the correct API endpoint to receive all webhooks" do
-      Paymill.should_receive(:request).with(:get, "webhooks/", {}).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:get, "webhooks/", {}).and_return("data" => {})
       Paymill::Webhook.all
     end
   end
 
   describe ".create" do
     it "makes a new POST request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:post, "webhooks", valid_attributes).and_return("data" => {})
+      expect(Paymill).to receive(:request).with(:post, "webhooks", valid_attributes).and_return("data" => {})
       Paymill::Webhook.create(valid_attributes)
     end
   end
 
   describe ".delete" do
     it "makes a new DELETE request using the correct API endpoint" do
-      Paymill.should_receive(:request).with(:delete, "webhooks/123", {}).and_return(true)
+      expect(Paymill).to receive(:request).with(:delete, "webhooks/123", {}).and_return(true)
       Paymill::Webhook.delete("123")
     end
   end
@@ -57,14 +57,14 @@ describe Paymill::Webhook do
     it "makes a new PUT request using the correct API endpoint" do
       changed_attributes = {:url => "<new-webhook-url>"}
       webhook.id    = "hook_123"
-      Paymill.should_receive(:request).with(:put, "webhooks/hook_123", changed_attributes).and_return("data" => changed_attributes)
+      expect(Paymill).to receive(:request).with(:put, "webhooks/hook_123", changed_attributes).and_return("data" => changed_attributes)
       webhook.update_attributes(changed_attributes)
     end
 
     it "should set the returned attributes on the instance" do
-      Paymill.should_receive(:request).and_return("data" => {:url => "<new-webhook-url>"})
+      expect(Paymill).to receive(:request).and_return("data" => {:url => "<new-webhook-url>"})
       webhook.update_attributes({})
-      webhook.url.should eql("<new-webhook-url>")
+      expect(webhook.url).to eql("<new-webhook-url>")
     end
   end
 end

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -17,17 +17,17 @@ describe Paymill do
 
       it "attempts to get a url with one param" do
         Paymill.request(:get, "transactions", { param_name: "param_value" })
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?param_name=param_value")
+        expect(WebMock).to have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?param_name=param_value")
       end
 
       it "attempts to get a url with more than one param" do
         Paymill.request(:get, "transactions", { client: "client_id", order: "created_at_desc" })
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?client=client_id&order=created_at_desc")
+        expect(WebMock).to have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions?client=client_id&order=created_at_desc")
       end
 
       it "doesn't add a question mark if no params" do
         Paymill.request(:get, "transactions", {})
-        WebMock.should have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions")
+        expect(WebMock).to have_requested(:get, "https://#{Paymill::api_key}:@#{Paymill::api_base}/#{Paymill::api_version}/transactions")
       end
     end
   end
@@ -55,7 +55,7 @@ describe Paymill do
 
     it 'allows to turn on development mode' do
       Paymill.development = true
-      expect(Paymill.development?).to be_true
+      expect(Paymill.development?).to be true
     end
 
     it 'allows to choose a logger' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require "paymill"
 require "rspec"
-require "rspec/autorun"
 require "webmock/rspec"
 require "pry"
 


### PR DESCRIPTION
Exposes a #to_h method on all paymill objects, which returns the original ruby hash parsed form the JSON API response, with parsed timestamps.

It can be convenient to have access to raw-er data, e.g. to save it as json in the db.
