### PR TITLE
Remove development mode entirely

### DIFF
--- a/lib/paymill.rb
+++ b/lib/paymill.rb
@@ -13,7 +13,6 @@ module Paymill
   @@api_base    = API_BASE
   @@api_version = API_VERSION
   @@api_port    = Net::HTTP.https_default_port
-  @@development = false
   @@logger      = Logger.new(STDOUT)
 
   autoload :Base,             "paymill/base"
@@ -100,20 +99,6 @@ module Paymill
   # @param [String] api_port The api port
   def self.api_port=(api_port)
     @@api_port = api_port
-  end
-
-  # Returns true if the development mode is on
-  #
-  # @return [Boolean] Development mode on or not
-  def self.development?
-    @@development
-  end
-
-  # Sets the development mode
-  #
-  # @param [Boolean] development Development mode on or not
-  def self.development=(development)
-    @@development = development
   end
 
   # Returns the current logger

--- a/spec/paymill_spec.rb
+++ b/spec/paymill_spec.rb
@@ -53,11 +53,6 @@ describe Paymill do
       expect(Paymill.api_port).to eq 3000
     end
 
-    it 'allows to turn on development mode' do
-      Paymill.development = true
-      expect(Paymill.development?).to eql(true)
-    end
-
     it 'allows to choose a logger' do
       logger = double(:logger)
       Paymill.logger = logger


### PR DESCRIPTION
It is not being used anywhere, anymore, so I don't see why we should
keep it.
